### PR TITLE
feat: adding support opening web browser to android

### DIFF
--- a/cmd/open.go
+++ b/cmd/open.go
@@ -58,6 +58,7 @@ var commands = map[string]string{
 	"windows": "start",
 	"darwin":  "open",
 	"linux":   "xdg-open",
+	"android": "xdg-open",
 }
 
 func OpenWebsite(path string) {


### PR DESCRIPTION
Not really a big one, but since termux also used `xdg-open`, and isn't recognized from open list (determined as android instead of linux), so I added a dedicated android entries here